### PR TITLE
Clarify the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Bring your personal gifs into your favourite chat client.
 
 ### Installation
 
+These instructions assume you've deployed Hubot to Heroku. Please make the appropriate adjustments for other hosting solutions.
+
 ```bash
 $ npm install --save hubot-gif-me
 $ hk set HUBOT_GIF_ME_ENDPOINT="blah"


### PR DESCRIPTION
Make it clear that the install instructions are for Heroku and that bots hosts other places (self-hosted, etc.) will need to adjust the instructions accordingly.
